### PR TITLE
* Fix a typo

### DIFF
--- a/parzen_ll.py
+++ b/parzen_ll.py
@@ -150,7 +150,7 @@ def main():
     if args.valid:
         valid = get_valid(args.dataset)
         ll = get_nll(valid, parzen, batch_size = batch_size)
-        se = ll.std() / numpy.sqrt(val.shape[0])
+        se = ll.std() / numpy.sqrt(valid.shape[0])
         print "Log-Likelihood of valid set = {}, se: {}".format(ll.mean(), se)
 
 


### PR DESCRIPTION
Fix a typo in `parzen_ll.py`
The following is the result using [my instruction on how to reproduce the original GAN](https://gist.github.com/jimmyahacker/b487d64e58664358f9b2af5aa8e71ad0) and wish this would help others
```
Using gpu device 0: Tesla K80 (CNMeM is disabled, CuDNN not available)
/scratch/sj2363/hsn/attack_generate/original_gan_reproduction/pylearn2/pylearn2/space/__init__.py:895: FutureWarning: Conversion of the second argument of issubdtype from `complex` to `np.complexfloating` is deprecated. In future, it will be treated as `np.complex128 == np.dtype(complex).type`.
  return np.issubdtype(dtype, np.complex)
Using Sigma: 0.01
0 0.5437917709350586 -249610.04500921787
10 0.4127103198658336 -254864.56703336554
20 0.4046180702391125 -256314.53794820592
30 0.40232555327876923 -256196.53144318963
40 0.4012015796289211 -255919.3469756813
50 0.4002548199073941 -255600.8114277227
60 0.3996614237300685 -255690.43841213794
70 0.3994017889801885 -256184.89072224603
80 0.3990846445531021 -255830.50266160985
90 0.3988482244722136 -255731.5973735723
Log-Likelihood of test set = -256075.399815, se: 791.576879859
0 0.39833712577819824 -255978.92391546787
10 0.3963735753839666 -253777.21132313827
20 0.39686526571001324 -253051.69069002144
30 0.3968393264278289 -253648.935089863
40 0.39672014771438224 -253051.69475388253
50 0.396716692868401 -252101.05537533303
60 0.39688189303288696 -253178.86357351087
70 0.39701688121741924 -253049.50480345203
80 0.3969559728363414 -252923.0343543182
90 0.3969241472390982 -253003.14902707504
Log-Likelihood of valid set = -252932.163116, se: 780.599199411
```